### PR TITLE
Handle multiple AWS Lambda event types

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-lambda-go/events"
+	"github.com/Techcadia/cloudtrail-console-actions/pkg/handler"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -36,11 +36,11 @@ func main() {
 	lambda.Start(S3Handler)
 }
 
-func S3Handler(ctx context.Context, s3Event events.S3Event) error {
-	log.Infof("S3 event: %v", s3Event)
+func S3Handler(ctx context.Context, event handler.Event) error {
+	log.Infof("S3 event: %v", event)
 
-	for _, s3Record := range s3Event.Records {
-		err := Stream(s3Record)
+	for _, record := range event.Records {
+		err := Stream(record)
 		if err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ func S3Handler(ctx context.Context, s3Event events.S3Event) error {
 	return nil
 }
 
-func FilterRecords(logFile *CloudTrailFile, evt events.S3EventRecord) error {
+func FilterRecords(logFile *CloudTrailFile, eventRecord handler.Record) error {
 	for _, record := range logFile.Records {
 		userIdentity, _ := record["userIdentity"].(map[string]interface{})
 
@@ -201,7 +201,7 @@ func FilterRecords(logFile *CloudTrailFile, evt events.S3EventRecord) error {
 			"event_name":   record["eventName"],
 			"account_id":   userIdentity["accountId"],
 			"event_id":     record["eventID"],
-			"s3_uri":       fmt.Sprintf("s3://%s/%s", evt.S3.Bucket.Name, evt.S3.Object.Key),
+			"s3_uri":       fmt.Sprintf("s3://%s/%s", eventRecord.S3.Bucket.Name, eventRecord.S3.Object.Key),
 		}).Info("Event")
 
 		if webhookUrl, ok := os.LookupEnv("SLACK_WEBHOOK"); ok {
@@ -259,11 +259,11 @@ func FilterRecords(logFile *CloudTrailFile, evt events.S3EventRecord) error {
 	return nil
 }
 
-func Stream(evt events.S3EventRecord) error {
-	s3ClientConfig := aws.NewConfig().WithRegion(evt.AWSRegion)
+func Stream(eventRecord handler.Record) error {
+	s3ClientConfig := aws.NewConfig().WithRegion(eventRecord.AWSRegion)
 	s3Client := s3.New(session.Must(session.NewSession()), s3ClientConfig)
-	s3Bucket := evt.S3.Bucket.Name
-	s3Object := evt.S3.Object.Key
+	s3Bucket := eventRecord.S3.Bucket.Name
+	s3Object := eventRecord.S3.Object.Key
 
 	log.Debugf("Reading %s from %s with client config of %+v", s3Object, s3Bucket, s3Client.Config)
 
@@ -280,7 +280,7 @@ func Stream(evt events.S3EventRecord) error {
 		return fmt.Errorf("%v: %v", s3Object, err)
 	}
 
-	err = FilterRecords(logFile, evt)
+	err = FilterRecords(logFile, eventRecord)
 	if err != nil {
 		return fmt.Errorf("%v: %v", s3Object, err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/Techcadia/cloudtrail-console-actions/pkg/handler"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -60,7 +61,7 @@ func testReadLogFile(t *testing.T, testData []byte, path string) error {
 		return err
 	}
 
-	FilterRecords(logFile, events.S3EventRecord{
+	FilterRecords(logFile, handler.Record{
 		AWSRegion: "us-east-1",
 		S3: events.S3Entity{
 			Bucket: events.S3Bucket{

--- a/pkg/handler/event.go
+++ b/pkg/handler/event.go
@@ -1,0 +1,168 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+type Event struct {
+	Records []Record
+}
+
+type Record struct {
+	EventSource    string
+	EventSourceArn string
+	AWSRegion      string
+	S3             events.S3Entity
+	SQS            events.SQSMessage
+	SNS            events.SNSEntity
+}
+
+type eventType int
+
+const (
+	unknownEventType eventType = iota
+	s3EventType
+	snsEventType
+	sqsEventType
+)
+
+func (event *Event) getEventType(data []byte) eventType {
+	temp := make(map[string]interface{})
+	json.Unmarshal(data, &temp)
+
+	recordsList, _ := temp["Records"].([]interface{})
+	record, _ := recordsList[0].(map[string]interface{})
+
+	var eventSource string
+
+	if es, ok := record["EventSource"]; ok {
+		eventSource = es.(string)
+	} else if es, ok := record["eventSource"]; ok {
+		eventSource = es.(string)
+	}
+
+	switch eventSource {
+	case "aws:s3":
+		return s3EventType
+	case "aws:sns":
+		return snsEventType
+	case "aws:sqs":
+		return sqsEventType
+	}
+
+	return unknownEventType
+}
+
+func (event *Event) UnmarshalJSON(data []byte) error {
+	var err error
+
+	switch event.getEventType(data) {
+	case s3EventType:
+		s3Event := &events.S3Event{}
+		err = json.Unmarshal(data, s3Event)
+
+		if err == nil {
+			return event.mapS3EventRecords(s3Event)
+		}
+
+	case snsEventType:
+		snsEvent := &events.SNSEvent{}
+		err = json.Unmarshal(data, snsEvent)
+
+		if err == nil {
+			return event.mapSNSEventRecords(snsEvent)
+		}
+
+	case sqsEventType:
+		sqsEvent := &events.SQSEvent{}
+		err = json.Unmarshal(data, sqsEvent)
+
+		if err == nil {
+			return event.mapSQSEventRecords(sqsEvent)
+		}
+	}
+
+	return err
+}
+
+func (event *Event) mapS3EventRecords(s3Event *events.S3Event) error {
+	event.Records = make([]Record, 0)
+
+	for _, s3Record := range s3Event.Records {
+		event.Records = append(event.Records, Record{
+			EventSource:    s3Record.EventSource,
+			EventSourceArn: s3Record.S3.Bucket.Arn,
+			AWSRegion:      s3Record.AWSRegion,
+			S3:             s3Record.S3,
+		})
+	}
+
+	return nil
+}
+
+func (event *Event) mapSNSEventRecords(snsEvent *events.SNSEvent) error {
+	event.Records = make([]Record, 0)
+
+	for _, snsRecord := range snsEvent.Records {
+		// decode sns message to s3 event
+		s3Event := &events.S3Event{}
+		err := json.Unmarshal([]byte(snsRecord.SNS.Message), s3Event)
+		if err != nil {
+			return errors.New("failed to decode sns message to an s3 event")
+		}
+
+		if len(s3Event.Records) == 0 {
+			return errors.New("s3 event records is empty")
+		}
+
+		for _, s3Record := range s3Event.Records {
+			topicArn, err := arn.Parse(snsRecord.SNS.TopicArn)
+			if err != nil {
+				return err
+			}
+
+			event.Records = append(event.Records, Record{
+				EventSource:    snsRecord.EventSource,
+				EventSourceArn: snsRecord.SNS.TopicArn,
+				AWSRegion:      topicArn.Region,
+				SNS:            snsRecord.SNS,
+				S3:             s3Record.S3,
+			})
+		}
+	}
+
+	return nil
+}
+
+func (event *Event) mapSQSEventRecords(sqsEvent *events.SQSEvent) error {
+	event.Records = make([]Record, 0)
+
+	for _, sqsRecord := range sqsEvent.Records {
+		// decode sqs body to s3 event
+		s3Event := &events.S3Event{}
+		err := json.Unmarshal([]byte(sqsRecord.Body), s3Event)
+		if err != nil {
+			return errors.New("failed to decode sqs body to an s3 event")
+		}
+
+		if len(s3Event.Records) == 0 {
+			return errors.New("s3 event records is empty")
+		}
+
+		for _, s3Record := range s3Event.Records {
+			event.Records = append(event.Records, Record{
+				EventSource:    sqsRecord.EventSource,
+				EventSourceArn: sqsRecord.EventSourceARN,
+				AWSRegion:      sqsRecord.AWSRegion,
+				SQS:            sqsRecord,
+				S3:             s3Record.S3,
+			})
+		}
+	}
+
+	return nil
+}

--- a/pkg/handler/event_test.go
+++ b/pkg/handler/event_test.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+func TestS3EventType(t *testing.T) {
+	s3EventObject := `{
+		"Records": [
+			{
+				"eventVersion": "2.1",
+				"eventSource": "aws:s3",
+				"awsRegion": "us-east-2",
+				"eventTime": "2019-09-03T19:37:27.192Z",
+				"eventName": "ObjectCreated:Put",
+				"userIdentity": {
+					"principalId": "AWS:AIDAINPONIXQXHT3IKHL2"
+				},
+				"requestParameters": {
+					"sourceIPAddress": "205.255.255.255"
+				},
+				"responseElements": {
+					"x-amz-request-id": "D82B88E5F771F645",
+					"x-amz-id-2": "vlR7PnpV2Ce81l0PRw6jlUpck7Jo5ZsQjryTjKlc5aLWGVHPZLj5NeC6qMa0emYBDXOo6QBU0Wo="
+				},
+				"s3": {
+					"s3SchemaVersion": "1.0",
+					"configurationId": "828aa6fc-f7b5-4305-8584-487c791949c1",
+					"bucket": {
+						"name": "lambda-artifacts-deafc19498e3f2df",
+						"ownerIdentity": {
+							"principalId": "A3I5XTEXAMAI3E"
+						},
+						"arn": "arn:aws:s3:::lambda-artifacts-deafc19498e3f2df"
+					},
+					"object": {
+						"key": "b21b84d653bb07b05b1e6b33684dc11b",
+						"size": 1305107,
+						"eTag": "b21b84d653bb07b05b1e6b33684dc11b",
+						"sequencer": "0C0F6F405D6ED209E1"
+					}
+				}
+			}
+		]
+	}`
+
+	event := &Event{}
+	want := regexp.MustCompile(`\b` + "lambda-artifacts-deafc19498e3f2df" + `\b`)
+
+	json.Unmarshal([]byte(s3EventObject), &event)
+	if !want.MatchString(event.Records[0].S3.Bucket.Name) {
+		t.Fatalf("failed to parse s3 event")
+	}
+}
+
+func TestSNSEventType(t *testing.T) {
+	snsEventObject := `{
+		"Records": [
+			{
+				"EventVersion": "1.0",
+				"EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+				"EventSource": "aws:sns",
+				"Sns": {
+					"SignatureVersion": "1",
+					"Timestamp": "2020-04-05T19:37:27.318Z",
+					"Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
+					"SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+					"MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+					"Message": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"eu-west-1\",\"eventTime\":\"2020-04-05T19:37:27.192Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDAINPONIXQXHT3IKHL2\"},\"requestParameters\":{\"sourceIPAddress\":\"205.255.255.255\"},\"responseElements\":{\"x-amz-request-id\":\"D82B88E5F771F645\",\"x-amz-id-2\":\"vlR7PnpV2Ce81l0PRw6jlUpck7Jo5ZsQjryTjKlc5aLWGVHPZLj5NeC6qMa0emYBDXOo6QBU0Wo=\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"828aa6fc-f7b5-4305-8584-487c791949c1\",\"bucket\":{\"name\":\"lambda-artifacts-deafc19498e3f2df\",\"ownerIdentity\":{\"principalId\":\"A3I5XTEXAMAI3E\"},\"arn\":\"arn:aws:s3:::lambda-artifacts-deafc19498e3f2df\"},\"object\":{\"key\":\"b21b84d653bb07b05b1e6b33684dc11b\",\"size\":1305107,\"eTag\":\"b21b84d653bb07b05b1e6b33684dc11b\",\"sequencer\":\"0C0F6F405D6ED209E1\"}}}]}",
+					"MessageAttributes": {},
+					"Type": "Notification",
+					"UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:eu-west-1:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+					"TopicArn":"arn:aws:sns:eu-west-1:123456789012:sns-lambda",
+					"Subject": "TestInvoke"
+				}
+			}
+		]
+	}`
+
+	event := &Event{}
+	want := regexp.MustCompile(`\b` + "lambda-artifacts-deafc19498e3f2df" + `\b`)
+
+	json.Unmarshal([]byte(snsEventObject), &event)
+	if !want.MatchString(event.Records[0].S3.Bucket.Name) {
+		t.Fatalf("failed to parse sns event")
+	}
+}
+
+func TestSQSEventType(t *testing.T) {
+	sqsEventObject := `{
+		"Records": [
+			{
+				"messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+				"receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+				"body": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"eu-west-1\",\"eventTime\":\"2020-04-05T19:37:27.192Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDAINPONIXQXHT3IKHL2\"},\"requestParameters\":{\"sourceIPAddress\":\"205.255.255.255\"},\"responseElements\":{\"x-amz-request-id\":\"D82B88E5F771F645\",\"x-amz-id-2\":\"vlR7PnpV2Ce81l0PRw6jlUpck7Jo5ZsQjryTjKlc5aLWGVHPZLj5NeC6qMa0emYBDXOo6QBU0Wo=\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"828aa6fc-f7b5-4305-8584-487c791949c1\",\"bucket\":{\"name\":\"lambda-artifacts-deafc19498e3f2df\",\"ownerIdentity\":{\"principalId\":\"A3I5XTEXAMAI3E\"},\"arn\":\"arn:aws:s3:::lambda-artifacts-deafc19498e3f2df\"},\"object\":{\"key\":\"b21b84d653bb07b05b1e6b33684dc11b\",\"size\":1305107,\"eTag\":\"b21b84d653bb07b05b1e6b33684dc11b\",\"sequencer\":\"0C0F6F405D6ED209E1\"}}}]}",
+				"attributes": {
+					"ApproximateReceiveCount": "1",
+					"SentTimestamp": "1586111847318",
+					"SenderId": "AIDAIENQZJOLO23YVJ4VO",
+					"ApproximateFirstReceiveTimestamp": "15861118483091"
+				},
+				"messageAttributes": {},
+				"md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+				"eventSource": "aws:sqs",
+				"eventSourceARN": "arn:aws:sqs:eu-west-1:123456789012:my-queue",
+				"awsRegion": "eu-west-1"
+			}
+		]
+	}`
+
+	event := &Event{}
+	want := regexp.MustCompile(`\b` + "lambda-artifacts-deafc19498e3f2df" + `\b`)
+
+	json.Unmarshal([]byte(sqsEventObject), &event)
+	if !want.MatchString(event.Records[0].S3.Bucket.Name) {
+		t.Fatalf("failed to parse sqs event")
+	}
+}


### PR DESCRIPTION
This PR implements the [Unmarshaler](https://golang.org/pkg/encoding/json/#Unmarshaler) interface for S3 event notifications, so they can be read not only directly from the S3 bucket, but also from SNS and SQS.