### PR TITLE
fix(slack): accountId can return nil; add fallback

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func init() {
 
 func main() {
 	log.SetFormatter(&log.JSONFormatter{})
-	log.Info("Starting v0.1.18")
+	log.Info("Starting v0.1.19")
 	lambda.Start(Handler)
 }
 
@@ -419,7 +419,7 @@ func FilterRecords(logFile *CloudTrailFile, eventRecord handler.Record) error {
 		if accountId, ok := userIdentity["accountId"].(string); ok {
 			recordAccount = accountId
 		}
-    if recipientAccountId, ok := record["recipientAccountId"].(string); ok {
+		if recipientAccountId, ok := record["recipientAccountId"].(string); ok {
 			recordAccount = fmt.Sprintf("Fallback: %s", recipientAccountId)
 		}
 

--- a/main.go
+++ b/main.go
@@ -418,10 +418,9 @@ func FilterRecords(logFile *CloudTrailFile, eventRecord handler.Record) error {
 		var recordAccount string
 		if accountId, ok := userIdentity["accountId"].(string); ok {
 			recordAccount = accountId
-		} else if recipientAccountId, ok := record["recipientAccountId"].(string); ok {
+		}
+    if recipientAccountId, ok := record["recipientAccountId"].(string); ok {
 			recordAccount = fmt.Sprintf("Fallback: %s", recipientAccountId)
-		} else {
-			recordAccount = "Unknown"
 		}
 
 		if webhookUrl, ok := os.LookupEnv("SLACK_WEBHOOK"); ok {


### PR DESCRIPTION
As seen in the below entry example from cognito-idp, sometimes the accountId is not present in the userIdentity field.  This change will allow a fallback for slack messaging to another field in the record, recipientAccountId, making it easier to debug the issue and find the event.

<img width="389" alt="image" src="https://github.com/user-attachments/assets/65c72380-89ea-4192-b0bd-12f8f2e2da32">

Cloudtrail event (fields redacted with `<[string]>`):

```json
{
    "eventVersion": "1.08",
    "userIdentity": {
        "type": "Unknown",
        "principalId": "Anonymous"
    },
    "eventTime": "2024-09-18T21:00:31Z",
    "eventSource": "cognito-idp.amazonaws.com",
    "eventName": "RespondToAuthChallenge",
    "awsRegion": "us-east-1",
    "sourceIPAddress": "XX.XX.XX.XX",
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
    "requestParameters": {
        "clientId": "<redacted>",
        "challengeName": "PASSWORD_VERIFIER",
        "challengeResponses": "HIDDEN_DUE_TO_SECURITY_REASONS",
        "clientMetadata": {}
    },
    "responseElements": {
        "challengeParameters": "HIDDEN_DUE_TO_SECURITY_REASONS",
        "authenticationResult": {
            "accessToken": "HIDDEN_DUE_TO_SECURITY_REASONS",
            "expiresIn": 3600,
            "tokenType": "Bearer",
            "refreshToken": "HIDDEN_DUE_TO_SECURITY_REASONS",
            "idToken": "HIDDEN_DUE_TO_SECURITY_REASONS"
        }
    },
    "additionalEventData": {
        "sub": "<GUID>"
    },
    "requestID": "<GUID>",
    "eventID": "<GUID>",
    "readOnly": false,
    "eventType": "AwsApiCall",
    "managementEvent": true,
    "recipientAccountId": "1234567890",
    "eventCategory": "Management",
    "tlsDetails": {
        "tlsVersion": "TLSv1.3",
        "cipherSuite": "TLS_AES_128_GCM_SHA256",
        "clientProvidedHostHeader": "cognito-idp.us-east-1.amazonaws.com"
    }
}
```