### PR TITLE
feat(efs): EFS is not fingered printed properly when Authenticated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/aws/aws-sdk-go v1.38.55
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/text v0.3.3
 )


### PR DESCRIPTION
This PR adds support for guarding errors from Authenticated Access of  EFS

  - Additional the strings.Title has been sunset in favor of cases
  - EFS https://docs.aws.amazon.com/efs/latest/ug/logging-using-cloudtrail.html emits this message every time a connection is successful. We are not worried about automated actions that contain an IAM permission for this action.