### PR TITLE
feat(aws): Lambda go1.x was sunset in 2024 and now is unavailable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifndef ARCH
-override ARCH = amd64
+override ARCH = arm64
 endif
 
 .PHONY: clean, build, zip
@@ -15,10 +15,12 @@ build: clean
 	GOOS=linux \
 	GOARCH=$(ARCH) \
 	go build \
+	-tags lambda.norpc \
 	-o ./bin/main \
 	main.go
 
 zip: build
-	zip ./dist/function.zip \
+	zip ./dist/function_$(ARCH).zip \
 	-j \
 	./bin/main
+	cd dist && find . -type f -name '*.zip' | xargs sha256sum >> sha256sums.txt

--- a/terraform/modules/cloudtrailconsole/s3/lambda.tf
+++ b/terraform/modules/cloudtrailconsole/s3/lambda.tf
@@ -3,12 +3,12 @@ resource "aws_lambda_function" "default" {
   source_code_hash               = filebase64sha256(lookup(var.lambda, "filepath", "${path.module}/../../../../dist/function.zip"))
   function_name                  = var.name
   handler                        = lookup(var.lambda, "handler", "main")
-  runtime                        = lookup(var.lambda, "runtime", "go1.x")
+  runtime                        = lookup(var.lambda, "runtime", "provided.al2023")
   timeout                        = lookup(var.lambda, "timeout", 15)
   memory_size                    = lookup(var.lambda, "memory", 128)
   reserved_concurrent_executions = lookup(var.lambda, "reserved_concurrent_executions", 10)
   role                           = aws_iam_role.default.arn
-  architectures                  = lookup(var.lambda, "architectures", ["x86_64"])
+  architectures                  = lookup(var.lambda, "architectures", ["arm64"])
 
   environment {
     variables = merge(

--- a/terraform/modules/cloudtrailconsole/sns/lambda.tf
+++ b/terraform/modules/cloudtrailconsole/sns/lambda.tf
@@ -3,12 +3,12 @@ resource "aws_lambda_function" "default" {
   source_code_hash               = filebase64sha256(lookup(var.lambda, "filepath", "${path.module}/../../../../dist/function.zip"))
   function_name                  = var.name
   handler                        = lookup(var.lambda, "handler", "main")
-  runtime                        = lookup(var.lambda, "runtime", "go1.x")
+  runtime                        = lookup(var.lambda, "runtime", "provided.al2023")
   timeout                        = lookup(var.lambda, "timeout", 15)
   memory_size                    = lookup(var.lambda, "memory", 128)
   reserved_concurrent_executions = lookup(var.lambda, "reserved_concurrent_executions", 10)
   role                           = aws_iam_role.default.arn
-  architectures                  = lookup(var.lambda, "architectures", ["x86_64"])
+  architectures                  = lookup(var.lambda, "architectures", ["arm64"])
 
   environment {
     variables = merge(


### PR DESCRIPTION
- We Add support for building on arm64 with al.2023 as the runtime.
- Refactor broken golang 1.19 code with broken bracket (wild!!!)