### PR TITLE
fix(aws): naming of binary files is sometimes harder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ build: clean
 	GOARCH=$(ARCH) \
 	go build \
 	-tags lambda.norpc \
-	-o ./bin/main \
+	-o ./bin/bootstrap \
 	main.go
 
 zip: build
 	zip ./dist/function_$(ARCH).zip \
 	-j \
-	./bin/main
+	./bin/bootstrap
 	cd dist && find . -type f -name '*.zip' | xargs sha256sum >> sha256sums.txt


### PR DESCRIPTION
- AWS seems to have a specific naming standard which appeared to be controlled via the handler definition. This doesn't actually seem to be the case and as such we need to rename the binary from `main` to `bootstrap`