### PR TITLE
fix(aws): Billing, Payments and binary naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ build: clean
 	GOARCH=$(ARCH) \
 	go build \
 	-tags lambda.norpc \
-	-o ./bin/main \
+	-o ./bin/bootstrap \
 	main.go
 
 zip: build
 	zip ./dist/function_$(ARCH).zip \
 	-j \
-	./bin/main
+	./bin/bootstrap
 	cd dist && find . -type f -name '*.zip' | xargs sha256sum >> sha256sums.txt

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func init() {
 
 func main() {
 	log.SetFormatter(&log.JSONFormatter{})
-	log.Info("Starting v0.2.0")
+	log.Info("Starting v0.2.1")
 	lambda.Start(Handler)
 }
 
@@ -91,6 +91,18 @@ func FilterRecords(logFile *CloudTrailFile, eventRecord handler.Record) error {
 		// billingconsole.amazonaws.com
 		if record["eventSource"] == "billingconsole.amazonaws.com" {
 			eventName = strings.TrimPrefix(eventName, "AWSPaymentPortalService.")
+			if eventName == "AssessSorChangeImpact" || eventName == "ConvertCurrencies" {
+				continue
+			}
+		}
+
+		// payments.amazonaws.com
+		if record["eventSource"] == "payments.amazonaws.com" {
+			if strings.Contains(eventName, "_Get") ||
+				strings.Contains(eventName, "_BatchGet") ||
+				strings.Contains(eventName, "_List") {
+				continue
+			}
 		}
 
 		// q.amazonaws.com


### PR DESCRIPTION
More information on why we renamed to bootstrap can be [found here](https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html)

- Billing Console [has documentation](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/logging-using-cloudtrail.html) on the APIs that are triggered in CloudTrail
- Payments does not so we have to just assume based on what we have seen in the past