### PR TITLE
fix(terraform): deprecated aws_region.name attribute; missing data source in s3 module

### DIFF
--- a/terraform/modules/cloudtrailconsole/s3/iam.tf
+++ b/terraform/modules/cloudtrailconsole/s3/iam.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "default" {
       "logs:CreateLogGroup",
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/aws/lambda/${var.name}",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:/aws/lambda/${var.name}",
     ]
   }
 
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "default" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.name}:log-stream:*",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.name}:log-stream:*",
     ]
   }
 

--- a/terraform/modules/cloudtrailconsole/s3/locals.tf
+++ b/terraform/modules/cloudtrailconsole/s3/locals.tf
@@ -1,1 +1,3 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/terraform/modules/cloudtrailconsole/sns/iam.tf
+++ b/terraform/modules/cloudtrailconsole/sns/iam.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "default" {
       "logs:CreateLogGroup",
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/aws/lambda/${var.name}",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:/aws/lambda/${var.name}",
     ]
   }
 
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "default" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.name}:log-stream:*",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.name}:log-stream:*",
     ]
   }
 


### PR DESCRIPTION
Terraform deprecated the `aws_region.current.name` in provider 6.0.0 in favor of `aws_region.current.region`.  Additionally, the `aws_region` data source was missing from the s3 module.

Signed-off-by: nomeelnoj <4316746+nomeelnoj@users.noreply.github.com>